### PR TITLE
feat: overhaul popup UI and implement all content-script features (v2…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "X Customizer",
-  "version": "1.0.19",
+  "version": "2.0.0",
   "description": "📽️ **Keep Focused, Stay Productive** Removes distracting elements inside X.com (formerly Twitter) for a cleaner experience.",
   "action": {
     "default_popup": "popup.html"

--- a/popup.html
+++ b/popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de" data-bs-theme="dark">
+<html lang="en" data-bs-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -25,11 +25,10 @@
             transition: background-color 0.3s ease;
         }
 
-        /* DIM MODE Klasse - wird via JS getoggled oder permanent gesetzt */
         body.dim-mode {
             background-color: var(--x-dim) !important;
         }
-        body.dim-mode .header-title, 
+        body.dim-mode .header-title,
         body.dim-mode .vertical-divider,
         body.dim-mode .border-top {
             border-color: var(--x-border-dim) !important;
@@ -110,13 +109,22 @@
         <div class="row mb-3">
             <div class="col-12 text-center">
                 <h4 class="header-title pb-3 mb-3">X Customizer</h4>
-                
+
+                <!-- MASTER TOGGLE -->
+                <div class="d-flex justify-content-between align-items-center rounded mb-3 px-2 py-2" style="background: rgba(255,255,255,0.05); border: 1px solid var(--x-border);">
+                    <span style="font-size: 0.9rem; font-weight: 700; color: #e7e9ea;">Extension Active</span>
+                    <div class="form-check form-switch mb-0">
+                        <input class="form-check-input" type="checkbox" id="extensionEnabled" role="switch"
+                               style="width: 2.5em; height: 1.25em; cursor: pointer;">
+                    </div>
+                </div>
+
                 <!-- DIM MODE TOGGLE -->
                 <div class="d-flex justify-content-center mb-2">
                     <div class="btn-group btn-group-sm w-75" role="group">
                         <input type="radio" class="btn-check" name="displayTheme" id="themeLightsOut" checked>
                         <label class="btn btn-outline-x" for="themeLightsOut">Lights Out</label>
-                        
+
                         <input type="radio" class="btn-check" name="displayTheme" id="themeDim">
                         <label class="btn btn-outline-x" for="themeDim">Dim Mode</label>
                     </div>
@@ -124,15 +132,19 @@
             </div>
         </div>
 
-        <!-- Hauptinhalt: Zwei Spalten -->
+        <!-- Main content: Two columns -->
         <div class="row">
-            <!-- LINKE SPALTE -->
+            <!-- LEFT COLUMN -->
             <div class="col-5">
                 <div class="mb-4">
                     <span class="section-title">Feed</span>
                     <div class="form-check mb-2">
                         <input class="form-check-input" type="checkbox" id="autoFollowing">
                         <label class="form-check-label" for="autoFollowing">Auto "Following"</label>
+                    </div>
+                    <div class="form-check mb-2">
+                        <input class="form-check-input" type="checkbox" id="hideReposts">
+                        <label class="form-check-label" for="hideReposts">Hide Reposts</label>
                     </div>
                     <div class="form-check mb-2">
                         <input class="form-check-input" type="checkbox" id="hidePremiumBanner">
@@ -154,15 +166,19 @@
                         <input class="form-check-input" type="checkbox" id="hideLive">
                         <label class="form-check-label" for="hideLive">Hide "Live on X"</label>
                     </div>
+                    <div class="form-check mb-2">
+                        <input class="form-check-input" type="checkbox" id="hideCommunitySuggestions">
+                        <label class="form-check-label" for="hideCommunitySuggestions">Hide Suggestions</label>
+                    </div>
                 </div>
             </div>
 
-            <!-- TRENNLINIE -->
+            <!-- DIVIDER -->
             <div class="col-2 d-flex justify-content-center">
                 <div class="vertical-divider"></div>
             </div>
 
-            <!-- RECHTE SPALTE -->
+            <!-- RIGHT COLUMN -->
             <div class="col-5">
                 <div class="mb-4">
                     <span class="section-title">Navigation</span>
@@ -189,11 +205,7 @@
                 </div>
 
                 <div class="mb-4">
-                    <span class="section-title">UI & Community</span>
-                    <div class="form-check mb-2">
-                        <input class="form-check-input" type="checkbox" id="hideCommunitySuggestions">
-                        <label class="form-check-label" for="hideCommunitySuggestions">Hide Suggestions</label>
-                    </div>
+                    <span class="section-title">UI</span>
                     <div class="form-check mb-2">
                         <input class="form-check-input" type="checkbox" id="removeTitleCounter">
                         <label class="form-check-label" for="removeTitleCounter">No Notif-Counter</label>
@@ -204,28 +216,28 @@
                     <span class="section-title">Distraction Blocking</span>
                     <div class="form-check mb-2">
                         <input class="form-check-input" type="checkbox" id="redirectFromNotifications">
-                        <label class="form-check-label" for="redirectFromNotifications">Redirect from notifications</label>
+                        <label class="form-check-label" for="redirectFromNotifications">Redirect from Notif.</label>
                     </div>
                     <div class="form-check mb-2">
                         <input class="form-check-input" type="checkbox" id="redirectFromTweets">
-                        <label class="form-check-label" for="redirectFromTweets">Redirect from tweets</label>
+                        <label class="form-check-label" for="redirectFromTweets">Redirect from Tweets</label>
                     </div>
                 </div>
             </div>
         </div>
 
-        <!-- Support / Links Bereich -->
+        <!-- Footer -->
         <div class="row border-top pt-3 mt-2">
             <div class="col-12 text-center">
                 <div class="d-flex justify-content-around mb-3">
-                    <a href="https://github.com" target="_blank" class="footer-link">Bugs / Features</a>
-                    <a href="https://github.com" target="_blank" class="footer-link">GitHub Repo</a>
+                    <a href="https://github.com/BaskLash/X-Feed-Cleaner/issues" target="_blank" class="footer-link">Bugs / Features</a>
+                    <a href="https://github.com/BaskLash/X-Feed-Cleaner" target="_blank" class="footer-link">GitHub Repo</a>
                 </div>
-                
-                <a href="https://chromewebstore.google.com..." target="_blank" class="text-decoration-none">
+
+                <a href="https://chromewebstore.google.com/detail/x-customizer/your-extension-id" target="_blank" class="text-decoration-none">
                     <button class="btn btn-x btn-sm w-100 text-white mb-2">⭐ Rate this Extension</button>
                 </a>
-                
+
                 <p class="small text-muted" id="nameYear" style="font-size: 0.7rem;"></p>
             </div>
         </div>

--- a/popup.js
+++ b/popup.js
@@ -1,53 +1,57 @@
 document.addEventListener("DOMContentLoaded", () => {
 
-  // Alle relevanten Felder
-  const fields = [
-    ...document.querySelectorAll('input[type="checkbox"]'),
-    ...document.querySelectorAll('input[name="displayTheme"]')
-  ];
+  const checkboxes = document.querySelectorAll('input[type="checkbox"]');
+  const radios     = document.querySelectorAll('input[name="displayTheme"]');
 
-  // 1. Alles laden
+  // ── Load stored settings ───────────────────────────────────────────────────
   chrome.storage.local.get(null, (data) => {
-    fields.forEach(el => {
-      if (el.type === "checkbox") {
+    checkboxes.forEach(el => {
+      // extensionEnabled defaults to true; all other checkboxes default to false
+      if (el.id === "extensionEnabled") {
+        el.checked = data[el.id] !== false;
+      } else {
         el.checked = !!data[el.id];
-      } else if (el.type === "radio") {
-        if (el.id === data.displayTheme) el.checked = true;
       }
     });
+
+    radios.forEach(el => {
+      if (el.id === data.displayTheme) el.checked = true;
+    });
+
+    // Reflect dim mode on the popup body itself
+    applyPopupDimMode(data.displayTheme);
   });
 
-  // 2. Bei jeder Änderung speichern
-  fields.forEach(el => {
+  // ── Save on change + notify content script ─────────────────────────────────
+  checkboxes.forEach(el => {
     el.addEventListener("change", () => {
-      if (el.type === "checkbox") {
-        chrome.storage.local.set({ [el.id]: el.checked });
-      } else if (el.type === "radio" && el.checked) {
-        chrome.storage.local.set({ displayTheme: el.id });
-      }
+      const key   = el.id;
+      const value = el.checked;
+      chrome.storage.local.set({ [key]: value });
+      notifyTab({ action: "settingsChanged" });
     });
   });
 
-  // Neu: Bei jeder Checkbox-Änderung → speichern + sofort ans Content-Script senden
-checkboxes.forEach(checkbox => {
-  checkbox.addEventListener("change", () => {
-    const key = checkbox.id;
-    const value = checkbox.checked;
+  radios.forEach(el => {
+    el.addEventListener("change", () => {
+      if (!el.checked) return;
+      const value = el.id;
+      chrome.storage.local.set({ displayTheme: value });
+      applyPopupDimMode(value);
+      notifyTab({ action: "settingsChanged" });
+    });
+  });
 
-    // 1. Speichern (wie bisher)
-    chrome.storage.local.set({ [key]: value });
-
-    // 2. Sofort ans aktive Tab senden
+  // ── Helpers ────────────────────────────────────────────────────────────────
+  function notifyTab(message) {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       if (!tabs[0]?.id) return;
-
-      chrome.tabs.sendMessage(tabs[0].id, {
-        action: "toggleSetting",
-        key: key,
-        value: value
-      });
+      chrome.tabs.sendMessage(tabs[0].id, message);
     });
-  });
-});
+  }
+
+  function applyPopupDimMode(theme) {
+    document.body.classList.toggle("dim-mode", theme === "themeDim");
+  }
 
 });

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,65 +1,260 @@
-// content.js
+'use strict';
 
-const GROK_SELECTOR = '[aria-label="Grok"]';
-const FOLLOW_SELECTOR = '[aria-label="Follow"]';
+// ─── Selectors ────────────────────────────────────────────────────────────────
+// Maps each popup setting key to the CSS selector(s) it controls.
+const TOGGLE_SELECTORS = {
+  hideGrok:                '[data-testid="AppTabBar_Grok_Link"]',
+  hideFollow:              '[aria-label="Follow"]',
+  hideNotifications:       '[data-testid="AppTabBar_Notifications_Link"]',
+  hideExplore:             '[data-testid="AppTabBar_Explore_Link"]',
+  hidePremiumNav:          '[href="/i/premium_sign_up"]',
+  hideTrends:              '[aria-label="Timeline: Trending now"]',
+  hideLive:                '[aria-label="Live on X"]',
+  hidePremiumBanner:       '[data-testid="upsell-section"]',
+  hideCommunitySuggestions:'[aria-label="Who to follow"]',
+  hideNewPosts:            '[data-testid="pillLabel"]',
+};
 
-function toggleGrok(hide) {
-  const elements = document.querySelectorAll(GROK_SELECTOR);
-  elements.forEach(el => { el.style.display = hide ? 'none' : ''; });
-  return elements.length > 0; // Gibt true zurück, wenn Elemente gefunden wurden
+const DIM_STYLE_ID       = 'x-customizer-dim-style';
+const REPOST_CONTEXT_SEL = '[data-testid="socialContext"]';
+const TWEET_ARTICLE_SEL  = '[data-testid="tweet"]';
+
+// ─── State ────────────────────────────────────────────────────────────────────
+let currentSettings  = {};
+let titleInterval    = null;
+let domObserver      = null;
+let rafPending       = false;
+
+// Track which paths we have already redirected from this session,
+// so we never redirect the same path twice (prevents redirect loops).
+const redirectedPaths = new Set();
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+function init() {
+  chrome.storage.local.get(null, (data) => {
+    currentSettings = data;
+    applyAll();
+    startDomObserver();
+    watchNavigation();
+  });
 }
 
-function toggleFollowSuggestions(hide) {
-  const elements = document.querySelectorAll(FOLLOW_SELECTOR);
-  elements.forEach(el => { el.style.display = hide ? 'none' : ''; });
-  return elements.length > 0;
+// ─── Full apply (settings change or navigation) ───────────────────────────────
+function applyAll() {
+  const enabled = currentSettings.extensionEnabled !== false;
+
+  if (!enabled) {
+    restoreAll();
+    return;
+  }
+
+  applyToggleSelectors();
+  applyReposts();
+  applyDimMode();
+  applyTitleCounter();
+  applyAutoFollowing();
+  checkRedirects();
 }
 
-function applySettings(settings) {
-  const grokFound = toggleGrok(settings.hideGrok === true);
-  const followFound = toggleFollowSuggestions(settings.hideFollow === true);
-  return { grokFound, followFound };
+// ─── Restore everything to X default ─────────────────────────────────────────
+function restoreAll() {
+  Object.values(TOGGLE_SELECTORS).forEach(sel => {
+    document.querySelectorAll(sel).forEach(el => el.style.removeProperty('display'));
+  });
+
+  document.querySelectorAll(TWEET_ARTICLE_SEL).forEach(el => {
+    el.style.removeProperty('display');
+  });
+
+  document.getElementById(DIM_STYLE_ID)?.remove();
+
+  if (titleInterval) {
+    clearInterval(titleInterval);
+    titleInterval = null;
+  }
 }
 
-// Intervall-Logik für das initiale Laden
-function startInitializationInterval() {
-  const checkInterval = setInterval(() => {
-    chrome.storage.local.get(["hideGrok", "hideFollow"], (settings) => {
-      const results = applySettings(settings);
-      
-      // Stop-Bedingung: Wenn beide aktivierten Funktionen ihre Ziele gefunden haben
-      const needGrok = settings.hideGrok === true;
-      const needFollow = settings.hideFollow === true;
-
-      const grokOk = !needGrok || (needGrok && results.grokFound);
-      const followOk = !needFollow || (needFollow && results.followFound);
-
-      if (grokOk && followOk) {
-        clearInterval(checkInterval);
-        console.log("DOM-Elemente gefunden und bearbeitet. Intervall gestoppt.");
+// ─── Element hiding ───────────────────────────────────────────────────────────
+function applyToggleSelectors() {
+  Object.entries(TOGGLE_SELECTORS).forEach(([key, selector]) => {
+    const hide = currentSettings[key] === true;
+    document.querySelectorAll(selector).forEach(el => {
+      if (hide) {
+        el.style.display = 'none';
+      } else {
+        el.style.removeProperty('display');
       }
     });
-  }, 500); // Prüft alle 500ms
-
-  // Sicherheitshalber nach 10 Sekunden stoppen, falls Elemente gar nicht existieren
-  setTimeout(() => clearInterval(checkInterval), 10000);
+  });
 }
 
-// ────────────────────────────────────────────────
-// Event Listener (Bleiben gleich für sofortige Updates)
+function applyReposts() {
+  const hide = currentSettings.hideReposts === true;
+  document.querySelectorAll(TWEET_ARTICLE_SEL).forEach(article => {
+    const isRepost = !!article.querySelector(REPOST_CONTEXT_SEL);
+    if (isRepost) {
+      if (hide) {
+        article.style.display = 'none';
+      } else {
+        article.style.removeProperty('display');
+      }
+    }
+  });
+}
 
+// ─── Dim mode (inject CSS into page) ─────────────────────────────────────────
+function applyDimMode() {
+  const isDim    = currentSettings.displayTheme === 'themeDim';
+  const existing = document.getElementById(DIM_STYLE_ID);
+
+  if (isDim && !existing) {
+    const style = document.createElement('style');
+    style.id = DIM_STYLE_ID;
+    style.textContent = [
+      'html, body { background-color: #15202b !important; }',
+      '[data-testid="primaryColumn"] { background-color: #15202b !important; }',
+      '[data-testid="sidebarColumn"] { background-color: #15202b !important; }',
+    ].join('\n');
+    document.head.appendChild(style);
+  } else if (!isDim && existing) {
+    existing.remove();
+  }
+}
+
+// ─── Notification counter in title ───────────────────────────────────────────
+function applyTitleCounter() {
+  if (currentSettings.removeTitleCounter) {
+    stripTitleCounter();
+    if (!titleInterval) {
+      titleInterval = setInterval(stripTitleCounter, 1000);
+    }
+  } else {
+    if (titleInterval) {
+      clearInterval(titleInterval);
+      titleInterval = null;
+    }
+  }
+}
+
+function stripTitleCounter() {
+  document.title = document.title.replace(/^\(\d+\+?\)\s*/, '');
+}
+
+// ─── Auto-switch to "Following" tab ──────────────────────────────────────────
+function applyAutoFollowing() {
+  if (!currentSettings.autoFollowing) return;
+  if (window.location.pathname !== '/home') return;
+
+  const followingTab = [...document.querySelectorAll('[role="tab"]')]
+    .find(tab => tab.textContent.trim() === 'Following');
+
+  if (followingTab && followingTab.getAttribute('aria-selected') !== 'true') {
+    followingTab.click();
+  }
+}
+
+// ─── Distraction redirects ────────────────────────────────────────────────────
+// Redirect only fires once per unique path per session, preventing loops.
+// Does NOT redirect from profile pages — only from /notifications and
+// individual tweet status URLs (/user/status/id).
+function checkRedirects() {
+  const path = window.location.pathname;
+
+  if (currentSettings.redirectFromNotifications && path === '/notifications') {
+    if (!redirectedPaths.has(path)) {
+      redirectedPaths.add(path);
+      navigateToHome();
+    }
+    return;
+  }
+
+  // Only match tweet status pages, not profile pages
+  if (currentSettings.redirectFromTweets && /^\/[^/]+\/status\/\d+/.test(path)) {
+    if (!redirectedPaths.has(path)) {
+      redirectedPaths.add(path);
+      navigateToHome();
+    }
+  }
+}
+
+function navigateToHome() {
+  // Prefer clicking X's internal home link to keep SPA navigation intact
+  const homeLink = document.querySelector('[data-testid="AppTabBar_Home_Link"]');
+  if (homeLink) {
+    homeLink.click();
+  } else {
+    window.location.href = 'https://x.com/home';
+  }
+}
+
+// ─── SPA navigation watcher ───────────────────────────────────────────────────
+// X is a React SPA — the content script runs once but the URL changes via
+// history.pushState. We intercept pushState/replaceState to re-apply settings.
+function watchNavigation() {
+  let lastPath = window.location.pathname;
+
+  function onPathChange() {
+    const current = window.location.pathname;
+    if (current === lastPath) return;
+    lastPath = current;
+    // Clear redirect tracking on real navigation so each page is evaluated fresh
+    redirectedPaths.clear();
+    applyAll();
+  }
+
+  const origPush    = history.pushState.bind(history);
+  const origReplace = history.replaceState.bind(history);
+
+  history.pushState = function (...args) {
+    origPush(...args);
+    onPathChange();
+  };
+
+  history.replaceState = function (...args) {
+    origReplace(...args);
+    onPathChange();
+  };
+
+  window.addEventListener('popstate', onPathChange);
+}
+
+// ─── DOM observer (handles dynamically injected elements) ─────────────────────
+function startDomObserver() {
+  if (domObserver) domObserver.disconnect();
+
+  domObserver = new MutationObserver(() => {
+    if (rafPending) return;
+    rafPending = true;
+    requestAnimationFrame(() => {
+      rafPending = false;
+      if (currentSettings.extensionEnabled !== false) {
+        applyToggleSelectors();
+        applyReposts();
+        applyAutoFollowing();
+      }
+    });
+  });
+
+  domObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+// ─── Settings change listeners ────────────────────────────────────────────────
 chrome.runtime.onMessage.addListener((message) => {
-  if (message?.action !== "toggleSetting") return;
-  chrome.storage.local.get(["hideGrok", "hideFollow"], (settings) => {
-    applySettings(settings);
+  if (message?.action !== 'settingsChanged') return;
+  chrome.storage.local.get(null, (data) => {
+    currentSettings = data;
+    redirectedPaths.clear();
+    applyAll();
   });
 });
 
-chrome.storage.onChanged.addListener(() => {
-  chrome.storage.local.get(["hideGrok", "hideFollow"], (settings) => {
-    applySettings(settings);
+chrome.storage.onChanged.addListener((changes) => {
+  Object.keys(changes).forEach(key => {
+    currentSettings[key] = changes[key].newValue;
   });
+  redirectedPaths.clear();
+  applyAll();
 });
 
-// Startpunkt
-startInitializationInterval();
+// ─── Start ────────────────────────────────────────────────────────────────────
+init();


### PR DESCRIPTION
….0.0)

Popup (popup.html / popup.js):
- Add prominent "Extension Active" master toggle (extensionEnabled)
- Add "Hide Reposts" checkbox to Feed section
- Move community suggestions to Sidebar section for better grouping
- Remove Time-of-Consumption, FAQ, and Buy-me-a-coffee (keep Rate Us)
- Fix ReferenceError: `checkboxes` was undefined in old popup.js
- Apply dim-mode styling to popup body when Dim Mode radio is selected
- Default extensionEnabled to true; all other checkboxes default to false

Content script (scripts/main.js):
- Full rewrite implementing ALL popup settings end-to-end
- Master toggle: extensionEnabled=false fully restores X default UI
- Hide reposts by detecting [data-testid="socialContext"] inside tweet articles
- Dim mode: inject <style> into X page for #15202b background
- Title counter removal: strip "(N+)" prefix via setInterval
- Auto-Following tab: click "Following" on /home if not already selected
- Redirect from notifications (/notifications → /home) with per-session deduplication to prevent redirect loops
- Redirect from tweets (only /user/status/id, NOT profile pages) to fix the navigation bug where profile pages were incorrectly redirected
- SPA navigation support: intercept history.pushState/replaceState and re-apply settings on every client-side route change
- MutationObserver (rAF-throttled) keeps hidden elements hidden as X injects new DOM nodes during infinite scroll / tab switches
- Proper restoreAll() removes all modifications without a page refresh

https://claude.ai/code/session_015LM7251RpbJJNRYhKFJa6c